### PR TITLE
Addition of a publicKey cache

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -4,6 +4,8 @@ var crypto = require('crypto');
 var https = require('https');
 var url = require('url');
 
+var cache = {}; // (publicKey -> cert) cache
+
 function verifyPublicKeyUrl(publicKeyUrl) {
   var parsedUrl = url.parse(publicKeyUrl);
   if (parsedUrl.protocol !== 'https:') {
@@ -37,6 +39,10 @@ function getAppleCertificate(publicKeyUrl, callback) {
     return;
   }
 
+  if (cache[publicKeyUrl]) {
+    return callback(null, cache[publicKeyUrl]);
+  }
+
   https.get(publicKeyUrl, function (res) {
     var data = '';
     res.on('data', function(chunk) {
@@ -44,6 +50,17 @@ function getAppleCertificate(publicKeyUrl, callback) {
     });
     res.on('end', function() {
       var cert = convertX509CertToPEM(data);
+
+      if (res.headers['cache-control']) { // if there's a cache-control header
+        var expire = res.headers['cache-control'].match(/max-age=([0-9]+)/);
+        if (expire) { // if we got max-age
+          cache[publicKeyUrl] = cert; // save in cache
+          // we'll expire the cache entry later, as per max-age
+          setTimeout(function () {
+            delete cache[publicKeyUrl];
+          }, parseInt(expire[1], 10) * 1000);
+        }
+      }
       callback(null, cert);
     });
   }).on('error', function(e) {

--- a/test/integrationTest.js
+++ b/test/integrationTest.js
@@ -1,0 +1,41 @@
+/*
+global toString
+ */
+'use strict';
+
+var assert = require('assert');
+var verifier = require('../lib/main');
+
+function isError(error) {
+  return toString.call(error) === '[object Error]';
+}
+
+// a real token is used to check caching behavior, but sharing it should have no security consequences
+var testToken = { 
+  playerId: 'G:1965586982',
+  publicKeyUrl: 'https://static.gc.apple.com/public-key/gc-prod-4.cer',
+  timestamp: 1565257031287,
+  signature: 'uqLBTr9Uex8zCpc1UQ1MIDMitb+HUat2Mah4Kw6AVLSGe0gGNJXlih2i5X+0ZwVY0S9zY2NHWi2gFjmhjt\/4kxWGMkupqXX5H\/qhE2m7hzox6lZJpH98ZEUbouWRfZX2ZhUlCkAX09oRNi7fI7mWL1\/o88MaI\/y6k6tLr14JTzmlxgdyhw+QRLxRPA6NuvUlRSJpyJ4aGtNH5\/wHdKQWL8nUnFYiYmaY8R7IjzNxPfy8UJTUWmeZvMSgND4u8EjADPsz7ZtZyWAPi8kYcAb6M8k0jwLD3vrYCB8XXyO2RQb/FY2TM4zJuI7PzLlvvgOJXbbfVtHx7Evnm5NYoyzgzw==',
+  salt: 'DzqqrQ==',
+  bundleId: 'cloud.xtralife.gamecenterauth'
+};
+
+describe.only('caching test', function () {
+  it('should be slow for first check',
+    function (done) {
+      verifier.verify(testToken, function (error) {
+        assert.equal(isError(error), false);
+        done();
+      });
+    });
+
+  it('should take less than 2ms for next checks',
+    function (done) {
+      this.timeout(2);
+      verifier.verify(testToken, function (error) {
+        assert.equal(isError(error), false);
+        done();
+      });
+    });
+});
+

--- a/test/integrationTest.js
+++ b/test/integrationTest.js
@@ -20,7 +20,7 @@ var testToken = {
   bundleId: 'cloud.xtralife.gamecenterauth'
 };
 
-describe.only('caching test', function () {
+describe('caching test', function () {
   it('should be slow for first check',
     function (done) {
       verifier.verify(testToken, function (error) {

--- a/test/integrationTest.js
+++ b/test/integrationTest.js
@@ -10,12 +10,17 @@ function isError(error) {
   return toString.call(error) === '[object Error]';
 }
 
-// a real token is used to check caching behavior, but sharing it should have no security consequences
+// a real token is used to check caching behavior
+// but sharing it should have no security consequences
 var testToken = { 
   playerId: 'G:1965586982',
   publicKeyUrl: 'https://static.gc.apple.com/public-key/gc-prod-4.cer',
   timestamp: 1565257031287,
-  signature: 'uqLBTr9Uex8zCpc1UQ1MIDMitb+HUat2Mah4Kw6AVLSGe0gGNJXlih2i5X+0ZwVY0S9zY2NHWi2gFjmhjt\/4kxWGMkupqXX5H\/qhE2m7hzox6lZJpH98ZEUbouWRfZX2ZhUlCkAX09oRNi7fI7mWL1\/o88MaI\/y6k6tLr14JTzmlxgdyhw+QRLxRPA6NuvUlRSJpyJ4aGtNH5\/wHdKQWL8nUnFYiYmaY8R7IjzNxPfy8UJTUWmeZvMSgND4u8EjADPsz7ZtZyWAPi8kYcAb6M8k0jwLD3vrYCB8XXyO2RQb/FY2TM4zJuI7PzLlvvgOJXbbfVtHx7Evnm5NYoyzgzw==',
+  signature: 'uqLBTr9Uex8zCpc1UQ1MIDMitb+HUat2Mah4Kw6AVLSGe0gGNJXlih2i5X+0Z'+
+  'wVY0S9zY2NHWi2gFjmhjt\/4kxWGMkupqXX5H\/qhE2m7hzox6lZJpH98ZEUbouWRfZX2ZhU'+
+  'lCkAX09oRNi7fI7mWL1\/o88MaI\/y6k6tLr14JTzmlxgdyhw+QRLxRPA6NuvUlRSJpyJ4aG'+
+  'tNH5\/wHdKQWL8nUnFYiYmaY8R7IjzNxPfy8UJTUWmeZvMSgND4u8EjADPsz7ZtZyWAPi8kY'+
+  'cAb6M8k0jwLD3vrYCB8XXyO2RQb/FY2TM4zJuI7PzLlvvgOJXbbfVtHx7Evnm5NYoyzgzw==',
   salt: 'DzqqrQ==',
   bundleId: 'cloud.xtralife.gamecenterauth'
 };


### PR DESCRIPTION
Hi! 
I've added a cache to avoid fetching Apple's publicKey for each check... The cache is using `publicKeyUrl` as a key, and expiration of the cache is done according to the HTTP `cache-control` header sent by Apple. An integration test shows how it's 100+ times faster after the first check.
I hope you'll merge/publish this upgrade